### PR TITLE
Remove ghcr token reference in deploy

### DIFF
--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -115,8 +115,8 @@ jobs:
         uses: docker/login-action@v1.10.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: 🚀 Build and push
         uses: docker/build-push-action@v2.7.0
         with:


### PR DESCRIPTION
Remove reference to ghcr token in deploy workflow as it appears its no longer necessary.