### PR TITLE
Add back separate ghcr token input to deploy

### DIFF
--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -12,6 +12,8 @@ on:
     secrets:
       DISPATCH_TOKEN:
         required: true
+      GHCR_TOKEN:
+        required: true
       GITHUB_TOKEN:
         required: true
 
@@ -116,7 +118,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: 🚀 Build and push
         uses: docker/build-push-action@v2.7.0
         with:


### PR DESCRIPTION
Re-add the separate input for a ghcr specific token as the github token isn't working for that.