### PR TITLE
Correctly use secret in stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: 🚀 Run stale
         uses: actions/stale@v4
         with:
-          repo-token: ${{ secrets.MY_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30
           days-before-close: 7
           remove-stale-when-updated: true


### PR DESCRIPTION
`GITHUB_TOKEN` not `MY_GITHUB_TOKEN`
