### PR TITLE
Remove `GITHUB_TOKEN` input from labels

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -11,9 +11,6 @@ on:
   schedule:
     - cron: "34 5 * * *"
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the `GITHUB_TOKEN` input from labels as Github doesn't seem to like overriding that secret and it appears its unnecessary to do so.