### PR TITLE
Remove `GITHUB_TOKEN` input from all workflows

### DIFF
--- a/.github/workflows/addon-ci.yaml
+++ b/.github/workflows/addon-ci.yaml
@@ -9,9 +9,6 @@ on:
         description: Overrides the detected slug
         required: false
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   information:

--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -14,8 +14,6 @@ on:
         required: true
       GHCR_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   information:

--- a/.github/workflows/base-deploy.yaml
+++ b/.github/workflows/base-deploy.yaml
@@ -7,8 +7,6 @@ on:
     secrets:
       GHCR_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   information:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -6,9 +6,6 @@ on:
   schedule:
     - cron: "0 9 * * *"
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -10,9 +10,6 @@ on:
       - unlabeled
       - synchronize
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   pr_labels:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -4,9 +4,6 @@ name: Release Drafter
 # yamllint disable-line rule:truthy
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   update_release_draft:

--- a/.github/workflows/repository-updater.yaml
+++ b/.github/workflows/repository-updater.yaml
@@ -5,8 +5,6 @@ name: Repository Updater
 on:
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
-        required: true
       UPDATER_TOKEN:
         required: true
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,9 +6,6 @@ on:
   schedule:
     - cron: "0 8 * * *"
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove `GITHUB_TOKEN` input from all workflows since Github does not like it anymore and its not necessary (see [here](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#overview))